### PR TITLE
DT-456: Fix form display issues

### DIFF
--- a/Forms/CheckEditor.Designer.cs
+++ b/Forms/CheckEditor.Designer.cs
@@ -84,18 +84,20 @@ namespace TvpMain.Forms
             // idLabel
             // 
             this.idLabel.AutoSize = true;
-            this.idLabel.Location = new System.Drawing.Point(6, 20);
+            this.idLabel.Location = new System.Drawing.Point(8, 25);
+            this.idLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.idLabel.Name = "idLabel";
-            this.idLabel.Size = new System.Drawing.Size(21, 13);
+            this.idLabel.Size = new System.Drawing.Size(23, 16);
             this.idLabel.TabIndex = 0;
             this.idLabel.Text = "ID:";
             // 
             // checkFixIdLabel
             // 
             this.checkFixIdLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.checkFixIdLabel.Location = new System.Drawing.Point(33, 16);
+            this.checkFixIdLabel.Location = new System.Drawing.Point(44, 19);
+            this.checkFixIdLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.checkFixIdLabel.Name = "checkFixIdLabel";
-            this.checkFixIdLabel.Size = new System.Drawing.Size(406, 20);
+            this.checkFixIdLabel.Size = new System.Drawing.Size(389, 22);
             this.checkFixIdLabel.TabIndex = 1;
             this.checkFixIdLabel.Text = "label1";
             this.checkFixIdLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -104,18 +106,20 @@ namespace TvpMain.Forms
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(6, 43);
+            this.label1.Location = new System.Drawing.Point(8, 53);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(90, 13);
+            this.label1.Size = new System.Drawing.Size(109, 16);
             this.label1.TabIndex = 2;
             this.label1.Text = "Check/Fix Name:";
             // 
             // checkFixNameTextBox
             // 
             this.checkFixNameTextBox.BackColor = System.Drawing.Color.LightYellow;
-            this.checkFixNameTextBox.Location = new System.Drawing.Point(145, 40);
+            this.checkFixNameTextBox.Location = new System.Drawing.Point(193, 49);
+            this.checkFixNameTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.checkFixNameTextBox.Name = "checkFixNameTextBox";
-            this.checkFixNameTextBox.Size = new System.Drawing.Size(294, 20);
+            this.checkFixNameTextBox.Size = new System.Drawing.Size(240, 22);
             this.checkFixNameTextBox.TabIndex = 3;
             this.checkFixNameTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.checkFixNameTextBox.MouseEnter += new System.EventHandler(this.CheckFixNameTextBox_MouseEnter);
@@ -131,9 +135,11 @@ namespace TvpMain.Forms
             this.groupBox2.Controls.Add(this.label4);
             this.groupBox2.Controls.Add(this.label3);
             this.groupBox2.Controls.Add(this.checkFindRegExTextBox);
-            this.groupBox2.Location = new System.Drawing.Point(13, 37);
+            this.groupBox2.Location = new System.Drawing.Point(17, 46);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(1164, 675);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox2.Size = new System.Drawing.Size(502, 507);
             this.groupBox2.TabIndex = 3;
             this.groupBox2.TabStop = false;
             // 
@@ -143,9 +149,11 @@ namespace TvpMain.Forms
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.jsEditor.Lexer = ScintillaNET.Lexer.Cpp;
-            this.jsEditor.Location = new System.Drawing.Point(9, 92);
+            this.jsEditor.Location = new System.Drawing.Point(8, 113);
+            this.jsEditor.Margin = new System.Windows.Forms.Padding(4);
             this.jsEditor.Name = "jsEditor";
-            this.jsEditor.Size = new System.Drawing.Size(1147, 577);
+            this.jsEditor.ScrollWidth = 1000;
+            this.jsEditor.Size = new System.Drawing.Size(486, 386);
             this.jsEditor.TabIndex = 6;
             this.jsEditor.CharAdded += new System.EventHandler<ScintillaNET.CharAddedEventArgs>(this.JsEditor_CharAdded);
             this.jsEditor.TextChanged += new System.EventHandler(this.JsEditor_TextChanged);
@@ -154,9 +162,10 @@ namespace TvpMain.Forms
             // label5
             // 
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(6, 69);
+            this.label5.Location = new System.Drawing.Point(8, 90);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(57, 13);
+            this.label5.Size = new System.Drawing.Size(71, 16);
             this.label5.TabIndex = 5;
             this.label5.Text = "JavaScript";
             // 
@@ -164,9 +173,10 @@ namespace TvpMain.Forms
             // 
             this.fixRegExTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.fixRegExTextBox.Location = new System.Drawing.Point(116, 43);
+            this.fixRegExTextBox.Location = new System.Drawing.Point(155, 53);
+            this.fixRegExTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.fixRegExTextBox.Name = "fixRegExTextBox";
-            this.fixRegExTextBox.Size = new System.Drawing.Size(1040, 20);
+            this.fixRegExTextBox.Size = new System.Drawing.Size(339, 22);
             this.fixRegExTextBox.TabIndex = 3;
             this.fixRegExTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.fixRegExTextBox.MouseEnter += new System.EventHandler(this.FixRegExTextBox_MouseEnter);
@@ -174,18 +184,20 @@ namespace TvpMain.Forms
             // label4
             // 
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(6, 46);
+            this.label4.Location = new System.Drawing.Point(8, 56);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(101, 13);
+            this.label4.Size = new System.Drawing.Size(126, 16);
             this.label4.TabIndex = 2;
             this.label4.Text = "Fix Replace RegEx:";
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(6, 20);
+            this.label3.Location = new System.Drawing.Point(8, 25);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(99, 13);
+            this.label3.Size = new System.Drawing.Size(121, 16);
             this.label3.TabIndex = 1;
             this.label3.Text = "Check Find RegEx:";
             // 
@@ -193,9 +205,10 @@ namespace TvpMain.Forms
             // 
             this.checkFindRegExTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.checkFindRegExTextBox.Location = new System.Drawing.Point(116, 16);
+            this.checkFindRegExTextBox.Location = new System.Drawing.Point(155, 20);
+            this.checkFindRegExTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.checkFindRegExTextBox.Name = "checkFindRegExTextBox";
-            this.checkFindRegExTextBox.Size = new System.Drawing.Size(1040, 20);
+            this.checkFindRegExTextBox.Size = new System.Drawing.Size(339, 22);
             this.checkFindRegExTextBox.TabIndex = 0;
             this.checkFindRegExTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.checkFindRegExTextBox.MouseEnter += new System.EventHandler(this.CheckFindRegExTextBox_MouseEnter);
@@ -203,9 +216,10 @@ namespace TvpMain.Forms
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(6, 69);
+            this.label2.Location = new System.Drawing.Point(8, 85);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(45, 13);
+            this.label2.Size = new System.Drawing.Size(56, 16);
             this.label2.TabIndex = 4;
             this.label2.Text = "Version:";
             // 
@@ -218,9 +232,10 @@ namespace TvpMain.Forms
             "BOOK",
             "CHAPTER",
             "VERSE"});
-            this.scopeCombo.Location = new System.Drawing.Point(145, 92);
+            this.scopeCombo.Location = new System.Drawing.Point(193, 113);
+            this.scopeCombo.Margin = new System.Windows.Forms.Padding(4);
             this.scopeCombo.Name = "scopeCombo";
-            this.scopeCombo.Size = new System.Drawing.Size(294, 21);
+            this.scopeCombo.Size = new System.Drawing.Size(240, 24);
             this.scopeCombo.TabIndex = 6;
             this.scopeCombo.MouseEnter += new System.EventHandler(this.ScopeCombo_MouseEnter);
             // 
@@ -244,19 +259,22 @@ namespace TvpMain.Forms
             this.groupBox3.Controls.Add(this.label6);
             this.groupBox3.Controls.Add(this.scopeCombo);
             this.groupBox3.Controls.Add(this.label2);
-            this.groupBox3.Location = new System.Drawing.Point(1183, 37);
+            this.groupBox3.Location = new System.Drawing.Point(527, 46);
+            this.groupBox3.Margin = new System.Windows.Forms.Padding(4);
             this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(445, 675);
+            this.groupBox3.Padding = new System.Windows.Forms.Padding(4);
+            this.groupBox3.Size = new System.Drawing.Size(441, 507);
             this.groupBox3.TabIndex = 7;
             this.groupBox3.TabStop = false;
             // 
             // versionTextBox
             // 
             this.versionTextBox.BackColor = System.Drawing.Color.LightYellow;
-            this.versionTextBox.Location = new System.Drawing.Point(145, 66);
+            this.versionTextBox.Location = new System.Drawing.Point(193, 81);
+            this.versionTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.versionTextBox.Mask = "0.0.0.0";
             this.versionTextBox.Name = "versionTextBox";
-            this.versionTextBox.Size = new System.Drawing.Size(294, 20);
+            this.versionTextBox.Size = new System.Drawing.Size(240, 22);
             this.versionTextBox.TabIndex = 16;
             this.versionTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.versionTextBox.MouseEnter += new System.EventHandler(this.VersionTextBox_MouseEnter);
@@ -264,9 +282,10 @@ namespace TvpMain.Forms
             // label10
             // 
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(6, 197);
+            this.label10.Location = new System.Drawing.Point(8, 254);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(60, 13);
+            this.label10.Size = new System.Drawing.Size(75, 16);
             this.label10.TabIndex = 15;
             this.label10.Text = "Description";
             // 
@@ -277,11 +296,12 @@ namespace TvpMain.Forms
             this.descriptionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.descriptionTextBox.Location = new System.Drawing.Point(6, 224);
+            this.descriptionTextBox.Location = new System.Drawing.Point(8, 276);
+            this.descriptionTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.descriptionTextBox.Multiline = true;
             this.descriptionTextBox.Name = "descriptionTextBox";
             this.descriptionTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.descriptionTextBox.Size = new System.Drawing.Size(430, 445);
+            this.descriptionTextBox.Size = new System.Drawing.Size(425, 223);
             this.descriptionTextBox.TabIndex = 14;
             this.descriptionTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.descriptionTextBox.MouseEnter += new System.EventHandler(this.DescriptionTextBox_MouseEnter);
@@ -289,17 +309,19 @@ namespace TvpMain.Forms
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(6, 174);
+            this.label9.Location = new System.Drawing.Point(8, 214);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(34, 13);
+            this.label9.Size = new System.Drawing.Size(42, 16);
             this.label9.TabIndex = 13;
             this.label9.Text = "Tags:";
             // 
             // tagsTextBox
             // 
-            this.tagsTextBox.Location = new System.Drawing.Point(145, 171);
+            this.tagsTextBox.Location = new System.Drawing.Point(193, 210);
+            this.tagsTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.tagsTextBox.Name = "tagsTextBox";
-            this.tagsTextBox.Size = new System.Drawing.Size(294, 20);
+            this.tagsTextBox.Size = new System.Drawing.Size(240, 22);
             this.tagsTextBox.TabIndex = 12;
             this.tagsTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.tagsTextBox.MouseEnter += new System.EventHandler(this.TagsTextBox_MouseEnter);
@@ -307,17 +329,19 @@ namespace TvpMain.Forms
             // label8
             // 
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(6, 148);
+            this.label8.Location = new System.Drawing.Point(8, 182);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(63, 13);
+            this.label8.Size = new System.Drawing.Size(78, 16);
             this.label8.TabIndex = 11;
             this.label8.Text = "Languages:";
             // 
             // languagesTextBox
             // 
-            this.languagesTextBox.Location = new System.Drawing.Point(145, 145);
+            this.languagesTextBox.Location = new System.Drawing.Point(193, 178);
+            this.languagesTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.languagesTextBox.Name = "languagesTextBox";
-            this.languagesTextBox.Size = new System.Drawing.Size(294, 20);
+            this.languagesTextBox.Size = new System.Drawing.Size(240, 22);
             this.languagesTextBox.TabIndex = 10;
             this.languagesTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.languagesTextBox.MouseEnter += new System.EventHandler(this.LanguagesTextBox_MouseEnter);
@@ -325,9 +349,10 @@ namespace TvpMain.Forms
             // defaultDescTextBox
             // 
             this.defaultDescTextBox.BackColor = System.Drawing.Color.LightYellow;
-            this.defaultDescTextBox.Location = new System.Drawing.Point(145, 119);
+            this.defaultDescTextBox.Location = new System.Drawing.Point(193, 146);
+            this.defaultDescTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.defaultDescTextBox.Name = "defaultDescTextBox";
-            this.defaultDescTextBox.Size = new System.Drawing.Size(294, 20);
+            this.defaultDescTextBox.Size = new System.Drawing.Size(240, 22);
             this.defaultDescTextBox.TabIndex = 9;
             this.defaultDescTextBox.TextChanged += new System.EventHandler(this.Content_TextChanged);
             this.defaultDescTextBox.MouseEnter += new System.EventHandler(this.DefaultDescTextBox_MouseEnter);
@@ -335,18 +360,20 @@ namespace TvpMain.Forms
             // label7
             // 
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(6, 122);
+            this.label7.Location = new System.Drawing.Point(8, 150);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(133, 13);
+            this.label7.Size = new System.Drawing.Size(164, 16);
             this.label7.TabIndex = 8;
             this.label7.Text = "Default Result Description:";
             // 
             // label6
             // 
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(6, 95);
+            this.label6.Location = new System.Drawing.Point(8, 117);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(41, 13);
+            this.label6.Size = new System.Drawing.Size(50, 16);
             this.label6.TabIndex = 7;
             this.label6.Text = "Scope:";
             // 
@@ -355,21 +382,23 @@ namespace TvpMain.Forms
             this.helpTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.helpTextBox.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.helpTextBox.Location = new System.Drawing.Point(12, 718);
+            this.helpTextBox.Location = new System.Drawing.Point(16, 560);
+            this.helpTextBox.Margin = new System.Windows.Forms.Padding(4);
             this.helpTextBox.Multiline = true;
             this.helpTextBox.Name = "helpTextBox";
-            this.helpTextBox.Size = new System.Drawing.Size(1616, 74);
+            this.helpTextBox.Size = new System.Drawing.Size(951, 90);
             this.helpTextBox.TabIndex = 8;
             // 
             // menuStrip
             // 
+            this.menuStrip.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.saveIconToolStripMenuItem,
             this.helpToolStripMenuItem});
             this.menuStrip.Location = new System.Drawing.Point(0, 0);
             this.menuStrip.Name = "menuStrip";
-            this.menuStrip.Size = new System.Drawing.Size(1640, 34);
+            this.menuStrip.Size = new System.Drawing.Size(985, 38);
             this.menuStrip.TabIndex = 13;
             this.menuStrip.Text = "menuStrip";
             // 
@@ -384,7 +413,7 @@ namespace TvpMain.Forms
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
             this.fileToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.F)));
             this.fileToolStripMenuItem.ShowShortcutKeys = false;
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 30);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 34);
             this.fileToolStripMenuItem.Text = "&File";
             // 
             // newToolStripMenuItem
@@ -392,7 +421,7 @@ namespace TvpMain.Forms
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
             this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
             this.newToolStripMenuItem.ShowShortcutKeys = false;
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(106, 22);
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(130, 26);
             this.newToolStripMenuItem.Text = "&New";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.NewToolStripMenuItem_Click);
             // 
@@ -401,7 +430,7 @@ namespace TvpMain.Forms
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
             this.openToolStripMenuItem.ShowShortcutKeys = false;
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(106, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(130, 26);
             this.openToolStripMenuItem.Text = "&Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.OpenToolStripMenuItem_Click);
             // 
@@ -410,7 +439,7 @@ namespace TvpMain.Forms
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
             this.saveToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
             this.saveToolStripMenuItem.ShowShortcutKeys = false;
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(106, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(130, 26);
             this.saveToolStripMenuItem.Text = "&Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.SaveToolStripMenuItem_Click);
             // 
@@ -419,7 +448,7 @@ namespace TvpMain.Forms
             this.publishToolStripMenuItem.Name = "publishToolStripMenuItem";
             this.publishToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.P)));
             this.publishToolStripMenuItem.ShowShortcutKeys = false;
-            this.publishToolStripMenuItem.Size = new System.Drawing.Size(106, 22);
+            this.publishToolStripMenuItem.Size = new System.Drawing.Size(130, 26);
             this.publishToolStripMenuItem.Text = "&Publish";
             this.publishToolStripMenuItem.Click += new System.EventHandler(this.PublishToolStripMenuItem_Click);
             // 
@@ -428,7 +457,7 @@ namespace TvpMain.Forms
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
             this.exitToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
             this.exitToolStripMenuItem.ShowShortcutKeys = false;
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(106, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(130, 26);
             this.exitToolStripMenuItem.Text = "E&xit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItem_Click);
             // 
@@ -445,7 +474,7 @@ namespace TvpMain.Forms
             this.saveIconToolStripMenuItem.ShortcutKeyDisplayString = "Ctlr+S";
             this.saveIconToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
             this.saveIconToolStripMenuItem.ShowShortcutKeys = false;
-            this.saveIconToolStripMenuItem.Size = new System.Drawing.Size(20, 25);
+            this.saveIconToolStripMenuItem.Size = new System.Drawing.Size(24, 29);
             this.saveIconToolStripMenuItem.Text = "saveIconMenuItem";
             this.saveIconToolStripMenuItem.ToolTipText = "Ctrl+S";
             this.saveIconToolStripMenuItem.Click += new System.EventHandler(this.SaveToolStripMenuItem_Click);
@@ -456,20 +485,20 @@ namespace TvpMain.Forms
             this.contactSupportToolStripMenuItem,
             this.licenseToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 30);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(55, 34);
             this.helpToolStripMenuItem.Text = "Help";
             // 
             // contactSupportToolStripMenuItem
             // 
             this.contactSupportToolStripMenuItem.Name = "contactSupportToolStripMenuItem";
-            this.contactSupportToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.contactSupportToolStripMenuItem.Size = new System.Drawing.Size(200, 26);
             this.contactSupportToolStripMenuItem.Text = "Contact Support";
             this.contactSupportToolStripMenuItem.Click += new System.EventHandler(this.contactSupportToolStripMenuItem_Click);
             // 
             // licenseToolStripMenuItem
             // 
             this.licenseToolStripMenuItem.Name = "licenseToolStripMenuItem";
-            this.licenseToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.licenseToolStripMenuItem.Size = new System.Drawing.Size(200, 26);
             this.licenseToolStripMenuItem.Text = "License";
             this.licenseToolStripMenuItem.Click += new System.EventHandler(this.LicenseToolStripMenuItem_Click);
             // 
@@ -480,14 +509,15 @@ namespace TvpMain.Forms
             // 
             // CheckEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1640, 804);
+            this.ClientSize = new System.Drawing.Size(985, 666);
             this.Controls.Add(this.helpTextBox);
             this.Controls.Add(this.groupBox3);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.menuStrip);
             this.MainMenuStrip = this.menuStrip;
+            this.Margin = new System.Windows.Forms.Padding(4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "CheckEditor";

--- a/Forms/CheckEditor.resx
+++ b/Forms/CheckEditor.resx
@@ -226,4 +226,7 @@
   <metadata name="publishWorker.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>125, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
 </root>

--- a/Forms/RunChecks.Designer.cs
+++ b/Forms/RunChecks.Designer.cs
@@ -83,73 +83,83 @@ namespace TvpMain.Forms
             this.runChecksTooltip = new System.Windows.Forms.ToolTip(this.components);
             this.runChecksMenu.SuspendLayout();
             this.checksGroupBox.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize) (this.checksList)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.checksList)).BeginInit();
             this.contextGroupBox.SuspendLayout();
             this.SuspendLayout();
             // 
             // runChecksMenu
             // 
-            this.runChecksMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {this.fileToolStripMenuItem, this.editorToolStripMenuItem, this.helpToolStripMenuItem});
-            this.runChecksMenu.Location = new System.Drawing.Point(10, 10);
+            this.runChecksMenu.ImageScalingSize = new System.Drawing.Size(20, 20);
+            this.runChecksMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.fileToolStripMenuItem,
+            this.editorToolStripMenuItem,
+            this.helpToolStripMenuItem});
+            this.runChecksMenu.Location = new System.Drawing.Point(13, 12);
             this.runChecksMenu.Name = "runChecksMenu";
-            this.runChecksMenu.Size = new System.Drawing.Size(892, 24);
+            this.runChecksMenu.Size = new System.Drawing.Size(1488, 38);
             this.runChecksMenu.TabIndex = 0;
             this.runChecksMenu.Text = "menuStrip1";
             // 
             // fileToolStripMenuItem
             // 
-            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {this.exitToolStripMenuItem});
+            this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.exitToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 34);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // exitToolStripMenuItem
             // 
             this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
-            this.exitToolStripMenuItem.Size = new System.Drawing.Size(93, 22);
+            this.exitToolStripMenuItem.Size = new System.Drawing.Size(116, 26);
             this.exitToolStripMenuItem.Text = "E&xit";
             this.exitToolStripMenuItem.Click += new System.EventHandler(this.ExitToolStripMenuItem_Click);
             // 
             // editorToolStripMenuItem
             // 
             this.editorToolStripMenuItem.Name = "editorToolStripMenuItem";
-            this.editorToolStripMenuItem.Size = new System.Drawing.Size(50, 20);
+            this.editorToolStripMenuItem.Size = new System.Drawing.Size(63, 34);
             this.editorToolStripMenuItem.Text = "Editor";
             this.editorToolStripMenuItem.Click += new System.EventHandler(this.EditorToolStripMenuItem_Click);
             // 
             // helpToolStripMenuItem
             // 
-            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {this.contactSupportToolStripMenuItem, this.licenseToolStripMenuItem});
+            this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.contactSupportToolStripMenuItem,
+            this.licenseToolStripMenuItem});
             this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.helpToolStripMenuItem.Size = new System.Drawing.Size(55, 34);
             this.helpToolStripMenuItem.Text = "Help";
             // 
             // contactSupportToolStripMenuItem
             // 
             this.contactSupportToolStripMenuItem.Name = "contactSupportToolStripMenuItem";
-            this.contactSupportToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.contactSupportToolStripMenuItem.Size = new System.Drawing.Size(200, 26);
             this.contactSupportToolStripMenuItem.Text = "Contact Support";
             this.contactSupportToolStripMenuItem.Click += new System.EventHandler(this.contactSupportToolStripMenuItem_Click);
             // 
             // licenseToolStripMenuItem
             // 
             this.licenseToolStripMenuItem.Name = "licenseToolStripMenuItem";
-            this.licenseToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            this.licenseToolStripMenuItem.Size = new System.Drawing.Size(200, 26);
             this.licenseToolStripMenuItem.Text = "License";
             this.licenseToolStripMenuItem.Click += new System.EventHandler(this.LicenseToolStripMenuItem_Click);
             // 
             // projectLabel
             // 
             this.projectLabel.AutoSize = true;
-            this.projectLabel.Location = new System.Drawing.Point(14, 44);
+            this.projectLabel.Location = new System.Drawing.Point(19, 54);
+            this.projectLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.projectLabel.Name = "projectLabel";
-            this.projectLabel.Size = new System.Drawing.Size(40, 13);
+            this.projectLabel.Size = new System.Drawing.Size(49, 16);
             this.projectLabel.TabIndex = 2;
             this.projectLabel.Text = "Project";
             // 
             // checksGroupBox
             // 
-            this.checksGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.checksGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.checksGroupBox.Controls.Add(this.tryToConnectButton);
             this.checksGroupBox.Controls.Add(this.filterLabel);
             this.checksGroupBox.Controls.Add(this.filterTextBox);
@@ -157,19 +167,21 @@ namespace TvpMain.Forms
             this.checksGroupBox.Controls.Add(this.setDefaultsToSelected);
             this.checksGroupBox.Controls.Add(this.resetToProjectDefaultsButton);
             this.checksGroupBox.Controls.Add(this.checksList);
-            this.checksGroupBox.Location = new System.Drawing.Point(13, 64);
+            this.checksGroupBox.Location = new System.Drawing.Point(17, 79);
+            this.checksGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checksGroupBox.Name = "checksGroupBox";
-            this.checksGroupBox.Size = new System.Drawing.Size(886, 427);
+            this.checksGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.checksGroupBox.Size = new System.Drawing.Size(1181, 526);
             this.checksGroupBox.TabIndex = 3;
             this.checksGroupBox.TabStop = false;
             this.checksGroupBox.Text = "Checks";
             // 
             // tryToConnectButton
             // 
-            this.tryToConnectButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.tryToConnectButton.Location = new System.Drawing.Point(110, 18);
+            this.tryToConnectButton.Location = new System.Drawing.Point(147, 22);
+            this.tryToConnectButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.tryToConnectButton.Name = "tryToConnectButton";
-            this.tryToConnectButton.Size = new System.Drawing.Size(98, 23);
+            this.tryToConnectButton.Size = new System.Drawing.Size(131, 28);
             this.tryToConnectButton.TabIndex = 6;
             this.tryToConnectButton.Text = "Try to Connect";
             this.tryToConnectButton.UseVisualStyleBackColor = true;
@@ -179,27 +191,30 @@ namespace TvpMain.Forms
             // filterLabel
             // 
             this.filterLabel.AutoSize = true;
-            this.filterLabel.Location = new System.Drawing.Point(396, 23);
+            this.filterLabel.Location = new System.Drawing.Point(528, 28);
+            this.filterLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.filterLabel.Name = "filterLabel";
-            this.filterLabel.Size = new System.Drawing.Size(146, 13);
+            this.filterLabel.Size = new System.Drawing.Size(180, 16);
             this.filterLabel.TabIndex = 5;
             this.filterLabel.Text = "Search (at least 3 characters)";
             // 
             // filterTextBox
             // 
-            this.filterTextBox.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.filterTextBox.Location = new System.Drawing.Point(548, 20);
+            this.filterTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.filterTextBox.Location = new System.Drawing.Point(731, 25);
+            this.filterTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.filterTextBox.Name = "filterTextBox";
-            this.filterTextBox.Size = new System.Drawing.Size(332, 20);
+            this.filterTextBox.Size = new System.Drawing.Size(441, 22);
             this.filterTextBox.TabIndex = 4;
             this.filterTextBox.TextChanged += new System.EventHandler(this.FilterTextBox_TextChanged);
             // 
             // refreshButton
             // 
-            this.refreshButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.refreshButton.Location = new System.Drawing.Point(6, 18);
+            this.refreshButton.Location = new System.Drawing.Point(8, 22);
+            this.refreshButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.refreshButton.Name = "refreshButton";
-            this.refreshButton.Size = new System.Drawing.Size(98, 23);
+            this.refreshButton.Size = new System.Drawing.Size(131, 28);
             this.refreshButton.TabIndex = 3;
             this.refreshButton.Text = "Fetch Updates";
             this.refreshButton.UseVisualStyleBackColor = true;
@@ -207,10 +222,11 @@ namespace TvpMain.Forms
             // 
             // setDefaultsToSelected
             // 
-            this.setDefaultsToSelected.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.setDefaultsToSelected.Location = new System.Drawing.Point(6, 398);
+            this.setDefaultsToSelected.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.setDefaultsToSelected.Location = new System.Drawing.Point(8, 490);
+            this.setDefaultsToSelected.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.setDefaultsToSelected.Name = "setDefaultsToSelected";
-            this.setDefaultsToSelected.Size = new System.Drawing.Size(257, 23);
+            this.setDefaultsToSelected.Size = new System.Drawing.Size(343, 28);
             this.setDefaultsToSelected.TabIndex = 2;
             this.setDefaultsToSelected.Text = "Set Selected Checks as the Project Defaults";
             this.setDefaultsToSelected.UseVisualStyleBackColor = true;
@@ -219,10 +235,11 @@ namespace TvpMain.Forms
             // 
             // resetToProjectDefaultsButton
             // 
-            this.resetToProjectDefaultsButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.resetToProjectDefaultsButton.Location = new System.Drawing.Point(738, 398);
+            this.resetToProjectDefaultsButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.resetToProjectDefaultsButton.Location = new System.Drawing.Point(984, 490);
+            this.resetToProjectDefaultsButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.resetToProjectDefaultsButton.Name = "resetToProjectDefaultsButton";
-            this.resetToProjectDefaultsButton.Size = new System.Drawing.Size(142, 23);
+            this.resetToProjectDefaultsButton.Size = new System.Drawing.Size(189, 28);
             this.resetToProjectDefaultsButton.TabIndex = 1;
             this.resetToProjectDefaultsButton.Text = "Reset to Project Defaults";
             this.resetToProjectDefaultsButton.UseVisualStyleBackColor = true;
@@ -234,26 +251,35 @@ namespace TvpMain.Forms
             this.checksList.AllowUserToAddRows = false;
             this.checksList.AllowUserToDeleteRows = false;
             this.checksList.AllowUserToResizeRows = false;
-            this.checksList.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.checksList.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.checksList.AutoSizeColumnsMode = System.Windows.Forms.DataGridViewAutoSizeColumnsMode.Fill;
             dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
             dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             this.checksList.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
             this.checksList.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.checksList.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {this.CFSelected, this.CFName, this.Version, this.CFLanguages, this.CFTags, this.Id});
-            this.checksList.Location = new System.Drawing.Point(6, 46);
+            this.checksList.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.CFSelected,
+            this.CFName,
+            this.Version,
+            this.CFLanguages,
+            this.CFTags,
+            this.Id});
+            this.checksList.Location = new System.Drawing.Point(8, 57);
+            this.checksList.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.checksList.MultiSelect = false;
             this.checksList.Name = "checksList";
             this.checksList.ReadOnly = true;
             this.checksList.RowHeadersVisible = false;
             this.checksList.RowHeadersWidthSizeMode = System.Windows.Forms.DataGridViewRowHeadersWidthSizeMode.AutoSizeToDisplayedHeaders;
             this.checksList.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.checksList.Size = new System.Drawing.Size(874, 346);
+            this.checksList.Size = new System.Drawing.Size(1165, 426);
             this.checksList.TabIndex = 0;
             this.checksList.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ChecksList_CellClick);
             this.checksList.CellDoubleClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.ChecksList_EditCheck);
@@ -265,16 +291,17 @@ namespace TvpMain.Forms
             this.CFSelected.FalseValue = "false";
             this.CFSelected.FillWeight = 20F;
             this.CFSelected.HeaderText = "Selected";
+            this.CFSelected.MinimumWidth = 6;
             this.CFSelected.Name = "CFSelected";
             this.CFSelected.ReadOnly = true;
             this.CFSelected.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
             this.CFSelected.TrueValue = "true";
-            this.CFSelected.Width = 82;
             // 
             // CFName
             // 
             this.CFName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.CFName.HeaderText = "Name";
+            this.CFName.MinimumWidth = 6;
             this.CFName.Name = "CFName";
             this.CFName.ReadOnly = true;
             // 
@@ -283,9 +310,10 @@ namespace TvpMain.Forms
             this.Version.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.Version.FillWeight = 80F;
             this.Version.HeaderText = "Version";
+            this.Version.MinimumWidth = 6;
             this.Version.Name = "Version";
             this.Version.ReadOnly = true;
-            this.Version.Width = 74;
+            this.Version.Width = 92;
             // 
             // CFLanguages
             // 
@@ -296,7 +324,7 @@ namespace TvpMain.Forms
             this.CFLanguages.Name = "CFLanguages";
             this.CFLanguages.ReadOnly = true;
             this.CFLanguages.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.CFLanguages.Width = 94;
+            this.CFLanguages.Width = 117;
             // 
             // CFTags
             // 
@@ -307,18 +335,20 @@ namespace TvpMain.Forms
             this.CFTags.Name = "CFTags";
             this.CFTags.ReadOnly = true;
             this.CFTags.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.CFTags.Width = 70;
+            this.CFTags.Width = 73;
             // 
             // Id
             // 
             this.Id.HeaderText = "Id";
+            this.Id.MinimumWidth = 6;
             this.Id.Name = "Id";
             this.Id.ReadOnly = true;
             this.Id.Visible = false;
             // 
             // contextGroupBox
             // 
-            this.contextGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.contextGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.contextGroupBox.Controls.Add(this.toChapterLabel);
             this.contextGroupBox.Controls.Add(this.chapterLabel);
             this.contextGroupBox.Controls.Add(this.chooseBooksButton);
@@ -328,38 +358,43 @@ namespace TvpMain.Forms
             this.contextGroupBox.Controls.Add(this.chooseBooksText);
             this.contextGroupBox.Controls.Add(this.chooseBooksRadioButton);
             this.contextGroupBox.Controls.Add(this.currentBookRadioButton);
-            this.contextGroupBox.Location = new System.Drawing.Point(13, 497);
+            this.contextGroupBox.Location = new System.Drawing.Point(17, 612);
+            this.contextGroupBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.contextGroupBox.Name = "contextGroupBox";
-            this.contextGroupBox.Size = new System.Drawing.Size(886, 82);
+            this.contextGroupBox.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.contextGroupBox.Size = new System.Drawing.Size(1181, 101);
             this.contextGroupBox.TabIndex = 4;
             this.contextGroupBox.TabStop = false;
             // 
             // toChapterLabel
             // 
-            this.toChapterLabel.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.toChapterLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.toChapterLabel.AutoSize = true;
-            this.toChapterLabel.Location = new System.Drawing.Point(783, 21);
+            this.toChapterLabel.Location = new System.Drawing.Point(1044, 26);
+            this.toChapterLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.toChapterLabel.Name = "toChapterLabel";
-            this.toChapterLabel.Size = new System.Drawing.Size(16, 13);
+            this.toChapterLabel.Size = new System.Drawing.Size(18, 16);
             this.toChapterLabel.TabIndex = 8;
             this.toChapterLabel.Text = "to";
             // 
             // chapterLabel
             // 
-            this.chapterLabel.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.chapterLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.chapterLabel.AutoSize = true;
-            this.chapterLabel.Location = new System.Drawing.Point(647, 21);
+            this.chapterLabel.Location = new System.Drawing.Point(863, 26);
+            this.chapterLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.chapterLabel.Name = "chapterLabel";
-            this.chapterLabel.Size = new System.Drawing.Size(49, 13);
+            this.chapterLabel.Size = new System.Drawing.Size(61, 16);
             this.chapterLabel.TabIndex = 7;
             this.chapterLabel.Text = "Chapters";
             // 
             // chooseBooksButton
             // 
-            this.chooseBooksButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.chooseBooksButton.Location = new System.Drawing.Point(805, 46);
+            this.chooseBooksButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.chooseBooksButton.Location = new System.Drawing.Point(1073, 57);
+            this.chooseBooksButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chooseBooksButton.Name = "chooseBooksButton";
-            this.chooseBooksButton.Size = new System.Drawing.Size(75, 23);
+            this.chooseBooksButton.Size = new System.Drawing.Size(100, 28);
             this.chooseBooksButton.TabIndex = 6;
             this.chooseBooksButton.Text = "Choose...";
             this.chooseBooksButton.UseVisualStyleBackColor = true;
@@ -368,54 +403,61 @@ namespace TvpMain.Forms
             // 
             // toChapterDropDown
             // 
-            this.toChapterDropDown.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.toChapterDropDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.toChapterDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.toChapterDropDown.FormattingEnabled = true;
-            this.toChapterDropDown.Location = new System.Drawing.Point(805, 19);
+            this.toChapterDropDown.Location = new System.Drawing.Point(1073, 23);
+            this.toChapterDropDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.toChapterDropDown.Name = "toChapterDropDown";
-            this.toChapterDropDown.Size = new System.Drawing.Size(75, 21);
+            this.toChapterDropDown.Size = new System.Drawing.Size(99, 24);
             this.toChapterDropDown.TabIndex = 5;
             this.toChapterDropDown.MouseEnter += new System.EventHandler(this.ToChapterDropDown_MouseEnter);
             // 
             // fromChapterDropDown
             // 
-            this.fromChapterDropDown.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.fromChapterDropDown.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.fromChapterDropDown.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.fromChapterDropDown.FormattingEnabled = true;
-            this.fromChapterDropDown.Location = new System.Drawing.Point(702, 18);
+            this.fromChapterDropDown.Location = new System.Drawing.Point(936, 22);
+            this.fromChapterDropDown.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.fromChapterDropDown.Name = "fromChapterDropDown";
-            this.fromChapterDropDown.Size = new System.Drawing.Size(75, 21);
+            this.fromChapterDropDown.Size = new System.Drawing.Size(99, 24);
             this.fromChapterDropDown.TabIndex = 4;
             this.fromChapterDropDown.MouseEnter += new System.EventHandler(this.FromChapterDropDown_MouseEnter);
             // 
             // currentBookText
             // 
-            this.currentBookText.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.currentBookText.Location = new System.Drawing.Point(100, 19);
+            this.currentBookText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.currentBookText.Location = new System.Drawing.Point(133, 23);
+            this.currentBookText.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.currentBookText.Name = "currentBookText";
             this.currentBookText.ReadOnly = true;
-            this.currentBookText.Size = new System.Drawing.Size(541, 20);
+            this.currentBookText.Size = new System.Drawing.Size(720, 22);
             this.currentBookText.TabIndex = 3;
             this.currentBookText.MouseEnter += new System.EventHandler(this.CurrentBookRadioButton_MouseEnter);
             // 
             // chooseBooksText
             // 
-            this.chooseBooksText.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
-            this.chooseBooksText.Location = new System.Drawing.Point(100, 48);
+            this.chooseBooksText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.chooseBooksText.Location = new System.Drawing.Point(133, 59);
+            this.chooseBooksText.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chooseBooksText.Name = "chooseBooksText";
             this.chooseBooksText.ReadOnly = true;
-            this.chooseBooksText.Size = new System.Drawing.Size(699, 20);
+            this.chooseBooksText.Size = new System.Drawing.Size(931, 22);
             this.chooseBooksText.TabIndex = 2;
             this.chooseBooksText.Text = "*none*";
             this.chooseBooksText.MouseEnter += new System.EventHandler(this.ChooseBooksText_MouseEnter);
             // 
             // chooseBooksRadioButton
             // 
-            this.chooseBooksRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.chooseBooksRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.chooseBooksRadioButton.AutoSize = true;
-            this.chooseBooksRadioButton.Location = new System.Drawing.Point(6, 49);
+            this.chooseBooksRadioButton.Location = new System.Drawing.Point(8, 62);
+            this.chooseBooksRadioButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.chooseBooksRadioButton.Name = "chooseBooksRadioButton";
-            this.chooseBooksRadioButton.Size = new System.Drawing.Size(94, 17);
+            this.chooseBooksRadioButton.Size = new System.Drawing.Size(117, 20);
             this.chooseBooksRadioButton.TabIndex = 1;
             this.chooseBooksRadioButton.TabStop = true;
             this.chooseBooksRadioButton.Text = "Choose Books";
@@ -425,11 +467,12 @@ namespace TvpMain.Forms
             // 
             // currentBookRadioButton
             // 
-            this.currentBookRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.currentBookRadioButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.currentBookRadioButton.AutoSize = true;
-            this.currentBookRadioButton.Location = new System.Drawing.Point(7, 19);
+            this.currentBookRadioButton.Location = new System.Drawing.Point(9, 25);
+            this.currentBookRadioButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.currentBookRadioButton.Name = "currentBookRadioButton";
-            this.currentBookRadioButton.Size = new System.Drawing.Size(87, 17);
+            this.currentBookRadioButton.Size = new System.Drawing.Size(105, 20);
             this.currentBookRadioButton.TabIndex = 0;
             this.currentBookRadioButton.TabStop = true;
             this.currentBookRadioButton.Text = "Current Book";
@@ -439,20 +482,22 @@ namespace TvpMain.Forms
             // 
             // Copyright
             // 
-            this.Copyright.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.Copyright.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.Copyright.AutoSize = true;
-            this.Copyright.Location = new System.Drawing.Point(17, 700);
+            this.Copyright.Location = new System.Drawing.Point(23, 862);
+            this.Copyright.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.Copyright.Name = "Copyright";
-            this.Copyright.Size = new System.Drawing.Size(101, 13);
+            this.Copyright.Size = new System.Drawing.Size(148, 16);
             this.Copyright.TabIndex = 10;
-            this.Copyright.Text = MainConsts.COPYRIGHT;
+            this.Copyright.Text = "© 2020-2022 Biblica, Inc.";
             // 
             // runChecksButton
             // 
-            this.runChecksButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.runChecksButton.Location = new System.Drawing.Point(818, 695);
+            this.runChecksButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.runChecksButton.Location = new System.Drawing.Point(1091, 855);
+            this.runChecksButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.runChecksButton.Name = "runChecksButton";
-            this.runChecksButton.Size = new System.Drawing.Size(75, 23);
+            this.runChecksButton.Size = new System.Drawing.Size(100, 28);
             this.runChecksButton.TabIndex = 11;
             this.runChecksButton.Text = "Run Checks";
             this.runChecksButton.UseVisualStyleBackColor = true;
@@ -460,11 +505,12 @@ namespace TvpMain.Forms
             // 
             // cancelButton
             // 
-            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(737, 695);
+            this.cancelButton.Location = new System.Drawing.Point(983, 855);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(75, 23);
+            this.cancelButton.Size = new System.Drawing.Size(100, 28);
             this.cancelButton.TabIndex = 13;
             this.cancelButton.Text = "Cancel";
             this.cancelButton.UseVisualStyleBackColor = true;
@@ -472,22 +518,26 @@ namespace TvpMain.Forms
             // 
             // helpTextBox
             // 
-            this.helpTextBox.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.helpTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.helpTextBox.BackColor = System.Drawing.Color.PaleGoldenrod;
-            this.helpTextBox.Location = new System.Drawing.Point(13, 585);
+            this.helpTextBox.Location = new System.Drawing.Point(17, 720);
+            this.helpTextBox.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.helpTextBox.Multiline = true;
             this.helpTextBox.Name = "helpTextBox";
             this.helpTextBox.ReadOnly = true;
-            this.helpTextBox.Size = new System.Drawing.Size(886, 104);
+            this.helpTextBox.Size = new System.Drawing.Size(1180, 127);
             this.helpTextBox.TabIndex = 14;
             // 
             // projectNameText
             // 
-            this.projectNameText.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+            this.projectNameText.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.projectNameText.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.projectNameText.Location = new System.Drawing.Point(60, 40);
+            this.projectNameText.Location = new System.Drawing.Point(80, 49);
+            this.projectNameText.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.projectNameText.Name = "projectNameText";
-            this.projectNameText.Size = new System.Drawing.Size(839, 21);
+            this.projectNameText.Size = new System.Drawing.Size(1118, 25);
             this.projectNameText.TabIndex = 15;
             this.projectNameText.Text = "Project Name";
             this.projectNameText.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -498,10 +548,10 @@ namespace TvpMain.Forms
             // 
             // RunChecks
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(912, 732);
+            this.ClientSize = new System.Drawing.Size(1216, 901);
             this.Controls.Add(this.projectNameText);
             this.Controls.Add(this.helpTextBox);
             this.Controls.Add(this.cancelButton);
@@ -511,12 +561,13 @@ namespace TvpMain.Forms
             this.Controls.Add(this.checksGroupBox);
             this.Controls.Add(this.projectLabel);
             this.Controls.Add(this.runChecksMenu);
-            this.Icon = ((System.Drawing.Icon) (resources.GetObject("$this.Icon")));
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.runChecksMenu;
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "RunChecks";
-            this.Padding = new System.Windows.Forms.Padding(10, 10, 10, 25);
+            this.Padding = new System.Windows.Forms.Padding(13, 12, 13, 31);
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
             this.Text = "Run Checks";
             this.Load += new System.EventHandler(this.RunChecks_Load);
@@ -524,11 +575,12 @@ namespace TvpMain.Forms
             this.runChecksMenu.PerformLayout();
             this.checksGroupBox.ResumeLayout(false);
             this.checksGroupBox.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize) (this.checksList)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.checksList)).EndInit();
             this.contextGroupBox.ResumeLayout(false);
             this.contextGroupBox.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         private System.Windows.Forms.Button tryToConnectButton;


### PR DESCRIPTION
Reduces the initial size of the CheckEditor form window to roughly 1000px x 700px so it will fit on most screens.

Several buttons on the RunChecks form would move when the window height was adjusted. Changed these buttons to be anchored to the top of the window instead of the bottom.